### PR TITLE
Fix findings modal buttons

### DIFF
--- a/css/findings.css
+++ b/css/findings.css
@@ -323,3 +323,147 @@
   tbody td {
     vertical-align: middle;
   }
+
+  /* Modal overlay and content for Findings page */
+  .modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(17, 24, 39, 0.45);
+    z-index: 999;
+    padding: 20px;
+  }
+
+  .modal {
+    width: 600px;
+    max-width: 100%;
+    background: #ffffff;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+    border: 1px solid #eeeeee;
+    animation: modal-fade-in 200ms ease-out;
+  }
+
+  @keyframes modal-fade-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+  }
+
+  .modal-header h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 700;
+    color: #111;
+  }
+
+  .modal-close {
+    border: none;
+    background: transparent;
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+    color: #555;
+    padding: 4px 8px;
+    border-radius: 6px;
+  }
+
+  .modal-close:hover {
+    background: #f3f4f6;
+  }
+
+  .modal-body {
+    padding: 4px 0;
+    max-height: 65vh;
+    overflow-y: auto;
+  }
+
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 12px;
+  }
+
+  /* Generic buttons used in modals */
+  .btn {
+    border: none;
+    border-radius: 8px;
+    padding: 8px 14px;
+    font-weight: 700;
+    cursor: pointer;
+    font-size: 14px;
+  }
+
+  .btn-primary { background: #1E5ADC; color: #fff; }
+  .btn-primary:hover { filter: brightness(0.95); }
+
+  .btn-secondary { background: #E5E7EB; color: #111; }
+  .btn-secondary:hover { background: #d1d5db; }
+
+  .btn-danger { background: #ef4444; color: #fff; }
+  .btn-danger:hover { filter: brightness(0.95); }
+
+  /* Form rows inside modals */
+  .form-row {
+    display: flex;
+    flex-direction: column;
+    margin: 8px 0;
+  }
+
+  .form-row label {
+    font-weight: 600;
+    margin-bottom: 6px;
+    color: #111;
+  }
+
+  .form-row input[type="text"],
+  .form-row input[type="date"],
+  .form-row input[type="number"] {
+    padding: 10px 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    background: #fff;
+    font-size: 14px;
+    outline: none;
+  }
+
+  .form-row input:focus {
+    border-color: #6a93ff;
+    box-shadow: 0 0 0 3px rgba(106, 147, 255, 0.25);
+  }
+
+  /* Tasks list and items */
+  .tasks-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .task-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .task-item .weight {
+    margin-left: auto;
+    color: #555;
+    font-weight: 600;
+  }
+
+  /* Missing utilities used by JS */
+  .fill-lightgreen { background: #a7f3d0; }
+  .status-completed { background: #34d399; color: #064e3b; }


### PR DESCRIPTION
Add missing CSS styles for modals and buttons to `css/findings.css` to enable proper display of New, Filter, and Edit modals.

---
<a href="https://cursor.com/background-agent?bcId=bc-575b45bd-e70c-4ab7-905e-670921eab479">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-575b45bd-e70c-4ab7-905e-670921eab479">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

